### PR TITLE
pin python2.7 tests to st2 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
       # Don't install various StackStorm dependencies which are already
       # installed by CI again in the various check scripts
       ST2_INSTALL_DEPS: "0"
+      # 3.3 is the last version to support python27
+      ST2_BRANCH: "v3.3"
 
     steps:
       - checkout


### PR DESCRIPTION
StackStorm 3.3 is the last version to support 2.7. So, use the v3.3
branch instead of the master branch for the python 2.7 tests.
